### PR TITLE
优化策略: 失败默认重试一定次数; delay改成随机秒数

### DIFF
--- a/addDataToAmap.js
+++ b/addDataToAmap.js
@@ -13,13 +13,18 @@ export default function addDataToAmap(formData) {
             },
             formData
         };
-        request(options, function (error, response) {
-            if (error) throw new Error(error);
-            if (JSON.parse(response.body).status == 1) {
-                rs(1);
-            } else {
-                rs(0);
-            }
-        });
+        try {
+            request(options, function (error, response) {
+                if (error) throw new Error(error);
+                if (JSON.parse(response.body).status == 1) {
+                    rs(1);
+                } else {
+                    rs(0);
+                }
+            });
+        } catch (err) {
+            console.error(err);
+            rs(0);
+        }
     })
 }

--- a/config.js
+++ b/config.js
@@ -3,6 +3,7 @@ const config = {
     "baidu": "ditu.baidu.com-request-header-cookie",
     "amap": "amap.com-request-header-cookie",
     "amapToken": "amap.com-request-header-x-csrf-token",
+    "maxRetry": 15, //高德最大重试次数
     "delay": 10e3 // 高德请求延迟时间（毫秒）
 }
 export default config;

--- a/index.js
+++ b/index.js
@@ -5,35 +5,62 @@ import config from './config.js';
 
 (async () => {
     let list = await getFromBd();
+    // 打乱，下次重试不用从头开始
+    list = shuffle(list);
+    console.log(JSON.stringify(list));
+
+    let errCnt = 0; //err计数器
+
     let failList = [];
     let succList = [];
     for (let v of list) {
+        if(v.name == "HOME" || v.name == "家" || v.name == "公司"){
+            continue;
+        }
+
         let keyword = (v.name || "") + " | " + (v.city || "");
         let data = await transformData(encodeURIComponent(keyword));
         if (data === 0) {
-            console.log('被反爬虫了，请做以下处理尝试解决：\n' +
+            errCnt++;
+            if (errCnt >= config.maxRetry) {
+                console.error('被反爬虫了，请做以下处理尝试解决：\n' +
                 '1.登陆网页查询一个地点，解除验证弹窗，然后配置高德更新后的cookie和token\n' +
                 '2.加大请求延迟时间');
-            break;
+                break;
+            }
+            list.push({"name": v.name, "city":v.city});
+
+            let msec= parseInt(String(Math.random()).substr(2, 4));
+            console.warn(`可能被反爬虫了，本次跳过，等待 ${msec / 1e3}秒后继续...`)
+            await TimeAwait(msec);
+            continue;
         }
-        let succ = data && await addDataToAmap({
-            'data[0][id]': Date.now() + Math.random().sub,
+        let param = {
+            // 'data[0][id]': Date.now() + Math.random().sub,
+            'data[0][id]': data.point_x + data.point_y, //解决ID变化重试出现多个相同名称的地址
             'data[0][data][item_id]': Date.now() + String(Math.random()).substr(2, 4),
             'data[0][data][address]': data.address,
             'data[0][data][name]': data.name,
             'data[0][data][point_x]': data.point_x,
             'data[0][data][point_y]': data.point_y,
             'data[0][type]': '101'
-        });
+        }
+        let succ = data && await addDataToAmap(param);
+        console.log(param);
         if (!succ) {
             failList.push(keyword);
         } else {
             succList.push(keyword);
         }
+
+        errCnt = 0; //重置err计数器
+        let msec2 = parseInt(String(Math.random()).substr(2, 4)) * 2;
         console.log('导入成功：' + keyword);
-        console.log(`已成功${succList.length}个，${config.delay / 1e3}秒后导入下一个`)
+        console.log(`已成功${succList.length}个，${msec2 / 1e3}秒后导入下一个`)
+
         // 防反爬虫
-        await TimeAwait(config.delay);
+        await TimeAwait(msec2);
+        // await TimeAwait(config.delay);
     }
     failList.length && console.log(`失败的地点（${failList.length}个）：\n` + failList.join('\n'));
 })();
@@ -43,4 +70,7 @@ async function TimeAwait(ms) {
             rs();
         }, ms)
     })
+}
+function shuffle(arr) {
+    return arr.sort(() => Math.random() - 0.5);
 }

--- a/transformData.js
+++ b/transformData.js
@@ -26,14 +26,16 @@ export default function transformData(keywords) {
                 'method': 'GET',
                 'url': 'https://www.amap.com/detail/get/detail?id=' + pos.id,
                 'headers': {
-                    'Cookie': config.amap
+                    'Cookie': config.amap,
+                    'Referer': 'https://www.amap.com/',
+                    'x-csrf-token': config.amapToken
                 }
             };
             request(options2, function (error, response) {
                 if (error) throw new Error(error);
                 let d = JSON.parse(response.body);
                 if (!d.data) {
-                    console.log("get detail fail");
+                    console.log("get detail fail:" + response.body);
                     rs(0);
                     return;
                 }


### PR DESCRIPTION
实际测试效果比直接break成功率提高不少，原因是：query by keywords fail 下一次可能会成功，只有连续数十次失败才需要更换cookie和token。用该方式已经成功导入248个。

效果：
``` bash
get detail fail
可能被反爬虫了，本次跳过，等待 7.067秒后继续...
query by keywords fail
可能被反爬虫了，本次跳过，等待 3.757秒后继续...
query by keywords fail
可能被反爬虫了，本次跳过，等待 0.647秒后继续...
{
  'data[0][id]': '220918738101624377',
  'data[0][data][item_id]': '16280409152503364',
  'data[0][data][address]': '北京市海淀区新建宫门路19号',
  'data[0][data][name]': '颐和园',
  'data[0][data][point_x]': '220918738',
  'data[0][data][point_y]': '101624377',
  'data[0][type]': '101'
}
导入成功：颐和园 | 北京市
已成功15个，4.45秒后导入下一个
query by keywords fail
可能被反爬虫了，本次跳过，等待 17.733秒后继续...
```